### PR TITLE
appinfo: disable update check on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+## Fixed
+- Fixed rendering on 720p TVs
+- Disabled update prompt on startup
 
 ## [0.2.0] - 2021/12/23
 ### Fixed

--- a/assets/appinfo.json
+++ b/assets/appinfo.json
@@ -9,6 +9,7 @@
     "largeIcon": "largeIcon.png",
     "iconColor": "#ff0000",
     "support360Content": true,
+    "checkUpdateOnLaunch": false,
     "accessibility": {
         "supportsAudioGuidance": true
     },

--- a/assets/appinfo.json
+++ b/assets/appinfo.json
@@ -21,7 +21,6 @@
     "inAppSearchParams": "{\"contentTarget\":\"q=$SEARCH_KEYWORD\"}",
     "inAppVoiceIntent": "{\"contentTarget\":{\"intent\":\"$INTENT\",\"intentParam\":\"$INTENT_PARAM\",\"languageCode\":\"$LANG_CODE\"}}",
     "supportQueryRouting": "{\"amazonAlexa\":true,\"googleAssistant\":true}",
-    "resolution": "1920x1080",
     "enablePigScreenSaver": false,
     "trustLevel": "netcast",
     "privilegedJail": true,


### PR DESCRIPTION
This fixes update prompt on launch on webOS 1.x