### PR TITLE
Implement ThinkQ voice launch.

### DIFF
--- a/assets/appinfo.json
+++ b/assets/appinfo.json
@@ -14,12 +14,12 @@
     "supportsAudioGuidance": true
   },
   "vendorExtension": {
-    "userAgent": "$browserName$/$browserVersion$ ($platformName$-$platformVersion$), _TV_$chipSetName$/$firmwareVersion$ (LG, $modelName$, $networkMode$)",
+    "userAgent": "$browserName$/$browserVersion$ ($platformName$-$platformVersion$), _TV_O18/$firmwareVersion$ (LG, $modelName$, $networkMode$)",
     "allowCrossDomain": true
   },
   "deeplinkingParams": "{\"contentTarget\":\"v=$CONTENTID\"}",
-  "inAppSearchParams": "{\"contentTarget\":\"q=$SEARCH_KEYWORD\"}",
-  "inAppVoiceIntent": "{\"contentTarget\":{\"intent\":\"$INTENT\",\"intentParam\":\"$INTENT_PARAM\",\"languageCode\":\"$LANG_CODE\"}}",
+  "inAppSearchParams": "{\"target\":\"q=$SEARCH_KEYWORD\"}",
+  "inAppVoiceIntent": "{\"target\":{\"intent\":\"$INTENT\",\"intentParam\":\"$INTENT_PARAM\",\"languageCode\":\"$LANG_CODE\"}}",
   "supportQueryRouting": "{\"amazonAlexa\":true,\"googleAssistant\":true}",
   "enablePigScreenSaver": false,
   "trustLevel": "netcast",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,6 @@
+const YT_BASE_URL = new URL('https://www.youtube.com/tv#/');
+const CONTENT_INTENT_REGEX = /^.+(?=Content)/g;
+
 export function extractLaunchParams() {
   if (window.launchParams) {
     return JSON.parse(window.launchParams);
@@ -7,27 +10,62 @@ export function extractLaunchParams() {
 }
 
 export function handleLaunch(params) {
+  console.info('handleLaunch', params);
+
   // We use our custom "target" param, since launches with "contentTarget"
   // parameter do not respect "handlesRelaunch" appinfo option. We still
   // fallback to "contentTarget" if our custom param is not specified.
   //
   let { target, contentTarget = target } = params;
+  let href;
 
-  if (contentTarget && typeof contentTarget === 'string') {
-    if (contentTarget.indexOf('v=v=') != -1)
-      contentTarget = contentTarget.replace('v=v=', 'v=');
+  switch (typeof contentTarget) {
+    case 'string': {
+      if (contentTarget.indexOf(YT_BASE_URL.origin) === 0) {
+        console.info('Launching from direct contentTarget');
+        href = contentTarget;
+      } else {
+        // Out of app dial launch with second screen on home: { contentTarget: 'pairingCode=<UUID>&theme=cl&dialLaunch=watch' }
+        console.info('Launching from partial contentTarget');
+        if (contentTarget.indexOf('v=v=') === 0)
+          contentTarget = contentTarget.substring(2);
 
-    if (contentTarget.indexOf('https://www.youtube.com/tv?') === 0) {
-      console.info('Launching from direct contentTarget:', contentTarget);
-      window.location = contentTarget;
-    } else {
-      console.info('Launching from partial contentTarget:', contentTarget);
-      window.location = 'https://www.youtube.com/tv#/?' + contentTarget;
+        href = YT_BASE_URL.toString() + '?' + contentTarget;
+      }
+      break;
     }
-  } else {
-    console.info('Default launch');
-    window.location = 'https://www.youtube.com/tv#/';
+    case 'object': {
+      console.info('Voice launch');
+
+      const { intent, intentParam } = contentTarget;
+      // Ctrl+F tvhtml5LaunchUrlComponentChanged & REQUEST_ORIGIN_GOOGLE_ASSISTANT in base.js for info
+      // TODO: implement google assistant
+      const search = new URLSearchParams();
+      // contentTarget.intent's seen so far: PlayContent, SearchContent
+      const voiceContentIntent = intent
+        .match(CONTENT_INTENT_REGEX)?.[0]
+        ?.toLowerCase();
+
+      search.set('inApp', true);
+      search.set('vs', 9); // Voice System is VOICE_SYSTEM_LG_THINKQ
+      voiceContentIntent && search.set('va', voiceContentIntent);
+
+      // order is important
+      search.append('launch', 'voice');
+      voiceContentIntent === 'search' && search.append('launch', 'search');
+
+      search.set('vq', intentParam);
+
+      href = YT_BASE_URL + '?' + search.toString();
+      break;
+    }
+    default: {
+      console.info('Default launch');
+      href = YT_BASE_URL.toString();
+    }
   }
+
+  window.location.href = href;
 }
 
 /**


### PR DESCRIPTION
This pull request adds the PlayContent and SearchContent intent of ThinkQ's voice launch. I haven't seen another intent yet so that's all I've implemented. Those search parameters were obtained by going through youtube's base.js source code. I haven't tested this fully so you may want to give it a go before merging.