### PR TITLE
Fix screensaver bug

### DIFF
--- a/src/userScript.js
+++ b/src/userScript.js
@@ -1,7 +1,7 @@
 import 'whatwg-fetch';
 import './domrect-polyfill';
 
-import { handleLaunch } from './utils';
+import { handleLaunch, waitForChildAdd } from './utils';
 
 document.addEventListener(
   'webOSRelaunch',
@@ -15,3 +15,37 @@ document.addEventListener(
 import './adblock.js';
 import './sponsorblock.js';
 import './ui.js';
+
+// This IIFE is to keep the video element fill the entire window so that screensaver doesn't kick in.
+(async () => {
+  /** @type {HTMLVideoElement} */
+  const video = await waitForChildAdd(
+    document.body,
+    (node) => node instanceof HTMLVideoElement
+  );
+
+  const playerCtrlObs = new MutationObserver(() => {
+    const style = video.style;
+
+    const targetWidth = `${window.innerWidth}px`;
+    const targetHeight = `${window.innerHeight}px`;
+    const targetLeft = '0px';
+    // YT uses a negative top to hide player when not in use. Don't know why but let's not affect it.
+    const targetTop =
+      style.top === `-${window.innerHeight}px` ? style.top : '0px';
+
+    /**
+     * Check to see if identical before assignment as some webOS versions will trigger a mutation
+     * mutation event even if the assignment effectively does nothing, leading to an infinite loop.
+     */
+    style.width !== targetWidth && (style.width = targetWidth);
+    style.height !== targetHeight && (style.height = targetHeight);
+    style.left !== targetLeft && (style.left = targetLeft);
+    style.top !== targetTop && (style.top = targetTop);
+  });
+
+  playerCtrlObs.observe(video, {
+    attributes: true,
+    attributeFilter: ['style']
+  });
+})();

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,3 +29,49 @@ export function handleLaunch(params) {
     window.location = 'https://www.youtube.com/tv#/';
   }
 }
+
+/**
+ * Wait for a child element to be added that holds true for a predicate
+ * @template T
+ * @param {Element} parent
+ * @param {(node: Node) => node is T} predicate
+ * @param {AbortSignal=} abortSignal
+ * @return {Promise<T>}
+ */
+export async function waitForChildAdd(parent, predicate, abortSignal) {
+  return new Promise((resolve, reject) => {
+    const obs = new MutationObserver((mutations) => {
+      for (const mut of mutations) {
+        switch (mut.type) {
+          case 'attributes': {
+            if (predicate(mut.target)) {
+              obs.disconnect();
+              resolve(mut.target);
+              return;
+            }
+            break;
+          }
+          case 'childList': {
+            for (const node of mut.addedNodes) {
+              if (predicate(node)) {
+                obs.disconnect();
+                resolve(node);
+                return;
+              }
+            }
+            break;
+          }
+        }
+      }
+    });
+
+    if (abortSignal) {
+      abortSignal.addEventListener('abort', () => {
+        obs.disconnect();
+        reject(new Error('aborted'));
+      });
+    }
+
+    obs.observe(parent, { subtree: true, attributes: true, childList: true });
+  });
+}


### PR DESCRIPTION
This pull request fixes the issue where the screensaver comes in at the wrong time. The root cause was the video element not filling the entire window for videos that don't have a 16:9 aspect ratio. Tested to work on a full width, less-than-full height video on an LG C1. Also tested screensaver functionality when video is paused and when on browser page.

Suggested further testing before merging:
- Works on webOS < 6
- ~Works on videos with a width < `window.innerWidth`~ Tested to work with a 960x720 test pattern.

Closes #12 