### PR TITLE
stop sponsorblock on playback preview videos

### DIFF
--- a/src/sponsorblock.js
+++ b/src/sponsorblock.js
@@ -376,10 +376,31 @@ class SponsorBlockHandler {
 // shows my lack of understanding of javascript. (or both)
 window.sponsorblock = null;
 
+function uninitializeSponsorblock() {
+  if (!window.sponsorblock) {
+    return;
+  }
+  try {
+    window.sponsorblock.destroy();
+  } catch (err) {
+    console.warn('window.sponsorblock.destroy() failed!', err);
+  }
+  window.sponsorblock = null;
+}
+
 window.addEventListener(
   'hashchange',
   () => {
     const newURL = new URL(location.hash.substring(1), location.href);
+    // uninitialize sponsorblock when not on `/watch` path, to prevent
+    // it from attaching to playback preview video element loaded on
+    // home page
+    if (newURL.pathname !== '/watch' && window.sponsorblock) {
+      console.info('uninitializing sponsorblock on a non-video page');
+      uninitializeSponsorblock();
+      return;
+    }
+
     const videoID = newURL.searchParams.get('v');
     const needsReload =
       videoID &&
@@ -394,14 +415,7 @@ window.addEventListener(
     );
 
     if (needsReload) {
-      if (window.sponsorblock) {
-        try {
-          window.sponsorblock.destroy();
-        } catch (err) {
-          console.warn('window.sponsorblock.destroy() failed!', err);
-        }
-        window.sponsorblock = null;
-      }
+      uninitializeSponsorblock();
 
       if (configRead('enableSponsorBlock')) {
         window.sponsorblock = new SponsorBlockHandler(videoID);


### PR DESCRIPTION
### Symptom
1. Open the app
2. Select and play a video (try a video that has a skippable part early in the video - [try this one](https://www.youtube.com/tv?env_forceFullAnimation=1#/watch?v=ccA8pMbFbuc) maybe)
3. Go back to home and press left/right/up/down button to hover over another video
4. You will notice that any video you hover over, skips the same time segments as the one you opened earlier in step 2.
  i. You'll also see the notification for it as well
  ii. In console, you'll see the logs for the previous video ID, confirming that its executing previous video's skip segments

### Cause
When a video is loaded, we initialize SponsorBlock. However, if you go back to YouTube homepage, and hover on a video tile, it starts to play a video.

Since SponsorBlock is already initialized, the listeners for video element are still listening to video's `play`, `pause`, `timeupdate` and `durationchange` listener - technically, the video element on a `/watch` page is the same video element on home page for preview playback.

This causes it to execute back the `scheduleSkipHandler`.

### Ideal Solution
IDEALLY, we would want to load SponsorBlock for the video being played in the preview on homepage.

However, there is no way (or should I say an easy way) to know the video ID for the preview playback video.

### Proposed Solution
When the page is changed, and it is not the video page, uninitialize SponsorBlock.
