### PR TITLE
More performant YouTube Logo hide option.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,6 @@
 const CONFIG_KEY = 'ytaf-configuration';
 const defaultConfig = {
+  hideLogo: false,
   enableAdBlock: true,
   enableSponsorBlock: true,
   enableSponsorBlockSponsor: true,

--- a/src/ui.js
+++ b/src/ui.js
@@ -47,6 +47,7 @@ uiContainer.addEventListener(
 
 uiContainer.innerHTML = `
 <h1>webOS YouTube Extended</h1>
+<label for="__hide_logo"><input type="checkbox" id="__hide_logo" /> Hide YouTube Logo</label>
 <label for="__adblock"><input type="checkbox" id="__adblock" /> Enable AdBlocking</label>
 <label for="__sponsorblock"><input type="checkbox" id="__sponsorblock" /> Enable SponsorBlock</label>
 <blockquote>
@@ -61,6 +62,12 @@ uiContainer.innerHTML = `
 `;
 
 document.querySelector('body').appendChild(uiContainer);
+
+uiContainer.querySelector('#__hide_logo').checked = configRead('hideLogo');
+uiContainer.querySelector('#__hide_logo').addEventListener('change', (evt) => {
+  configWrite('hideLogo', evt.target.checked);
+  logoHideShow();
+});
 
 uiContainer.querySelector('#__adblock').checked = configRead('enableAdBlock');
 uiContainer.querySelector('#__adblock').addEventListener('change', (evt) => {
@@ -190,6 +197,18 @@ export function showNotification(text, time = 3000) {
   }, time);
 }
 
+// Hide youtube logo from the top right
+function logoHideShow() {
+  document.querySelector('ytlr-redux-connect-ytlr-logo-entity').style.opacity =
+    configRead('hideLogo') ? '0' : '1';
+}
+
 setTimeout(() => {
   showNotification('Press [GREEN] to open YTAF configuration screen');
+  logoHideShow();
 }, 2000);
+
+logoHideShow();
+setTimeout(() => {
+  logoHideShow();
+}, 4000);


### PR DESCRIPTION
This pull request adds an option to hide the YouTube logo from the top right corner of the app.

Me and the creator of [youtube-webos-cobalt](https://github.com/GuillaumeSmaha/youtube-webos-cobalt-app) modified the code of #56 a while ago to work without the deprecated [DOMNodeInserted](https://developer.mozilla.org/en-US/docs/Web/API/MutationEvent) event, thus making it more performant and up to date.