### PR TITLE
Build in production mode by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Ad-free YouTube app for webOS",
   "main": "index.js",
   "scripts": {
-    "build": "webpack",
+    "build": "webpack --mode=production",
+    "build:dev": "webpack --mode=development",
     "package": "ares-package -n dist",
     "deploy": "node tools/deploy.mjs",
     "launch": "ares-launch youtube.leanback.v4",


### PR DESCRIPTION
This will make webpack run in production mode during CI workflows, enabling minification etc.

If you still want development mode when building locally, you can use `npm run build:dev` instead.