### PR TITLE
Hopefully block additional ads

### DIFF
--- a/src/adblock.js
+++ b/src/adblock.js
@@ -22,6 +22,10 @@ JSON.parse = function () {
     r.adPlacements = [];
   }
 
+  if (Array.isArray(r.adSlots)) {
+    r.adSlots = [];
+  }
+
   // remove ads from home
   const homeSectionListRenderer =
     r?.contents?.tvBrowseRenderer?.content?.tvSurfaceContentRenderer?.content


### PR DESCRIPTION
Block `adSlots` in JSON responses, as seen in [this uBlock rule](https://github.com/uBlockOrigin/uAssets/blob/d54c02ba6b472a7eb8035e4bfe838180b8ca4866/filters/filters.txt#L48).

Thanks to @reisxd for the suggestion.