### PR TITLE
Don't send duplicate event on mouse click

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -84,7 +84,13 @@ function createOptionsPanel() {
         navigate(ARROW_KEY_CODE[evt.keyCode]);
       } else if (evt.keyCode === 13) {
         // "OK" button
-        document.querySelector(':focus').click();
+
+        // The YouTube app generates these "OK" events from clicks (including
+        // with the Magic Remote), and we don't want to send a duplicate click
+        // event for those. It seems isTrusted is only true for "real" events.
+        if (evt.isTrusted === true) {
+          document.activeElement.click();
+        }
       } else if (evt.keyCode === 27) {
         // Back button
         showOptionsPanel(false);


### PR DESCRIPTION
Apparently, the YouTube app generates key events with `keyCode` 13 (i.e., the "OK" button on webOS) when receives a `click` event.

Usually, we do the reverse; that is, we cause a `click` on the element with focus when a `keydown` with `keyCode` 13 is received. When such events are generated by the YouTube app, this leads to duplicate and incorrectly targeted `click` events.

The `isTrusted` property seems to provide a way to distinguish between events created by YouTube and WAM itself.

Fixes #139.