### PR TITLE
Add events for config value changes

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 const CONFIG_KEY = 'ytaf-configuration';
 
-export const configOptions = new Map([
+const configOptions = new Map([
   ['enableAdBlock', { default: true, desc: 'Enable ad blocking' }],
   ['enableSponsorBlock', { default: true, desc: 'Enable SponsorBlock' }],
   [
@@ -63,7 +63,7 @@ function configExists(key) {
   return configOptions.has(key);
 }
 
-export function getConfigDesc(key) {
+export function configGetDesc(key) {
   if (!configExists(key)) {
     throw new Error('tried to get desc for unknown config key: ' + key);
   }

--- a/src/ui.js
+++ b/src/ui.js
@@ -41,8 +41,16 @@ function createConfigCheckbox(key) {
   const elmInput = document.createElement('input');
   elmInput.type = 'checkbox';
   elmInput.checked = configRead(key);
-  elmInput.addEventListener('change', (evt) => {
+
+  /** @type {(evt: Event) => void} */
+  const changeHandler = (evt) => {
     configWrite(key, evt.target.checked);
+  };
+
+  elmInput.addEventListener('change', changeHandler);
+
+  configAddChangeListener(key, (evt) => {
+    elmInput.checked = evt.detail.newValue;
   });
 
   const elmLabel = document.createElement('label');

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,7 +1,7 @@
 /*global navigate*/
 import './spatial-navigation-polyfill.js';
 import './ui.css';
-import { configRead, configWrite, getConfigDesc } from './config.js';
+import { configRead, configWrite, configGetDesc } from './config.js';
 
 // We handle key events ourselves.
 window.__spatialNavigation__.keyMode = 'NONE';
@@ -48,7 +48,7 @@ function createConfigCheckbox(key) {
   const elmLabel = document.createElement('label');
   elmLabel.appendChild(elmInput);
   // Use non-breaking space (U+00A0)
-  elmLabel.appendChild(document.createTextNode('\u00A0' + getConfigDesc(key)));
+  elmLabel.appendChild(document.createTextNode('\u00A0' + configGetDesc(key)));
 
   return elmLabel;
 }


### PR DESCRIPTION
Adds the ability to listen for changes to a config value with `configAddChangeListener(key, callback)` (plus of course `configRemoveChangeListener()`).

Using this functionality, the options panel UI now updates automatically when settings are modified with `configWrite()`.

I'm not sure using `DocumentFragment`s is the best way (or even a good way) to do this. It does seem to work, though.