### PR TITLE
Remove shorts from Subscriptions tab

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,7 @@ const CONFIG_KEY = 'ytaf-configuration';
 
 const configOptions = new Map([
   ['enableAdBlock', { default: true, desc: 'Enable ad blocking' }],
+  ['removeShorts', { default: true, desc: 'Remove Shorts from subscriptions' }],
   ['enableSponsorBlock', { default: true, desc: 'Enable SponsorBlock' }],
   [
     'enableSponsorBlockSponsor',

--- a/src/shorts.js
+++ b/src/shorts.js
@@ -1,0 +1,44 @@
+/* eslint no-redeclare: 0 */
+/* global fetch:writable */
+import { configRead } from './config';
+
+const origParse = JSON.parse;
+JSON.parse = function () {
+  const r = origParse.apply(this, arguments);
+  if (!configRead('removeShorts')) {
+    return r;
+  }
+
+  // First page of subscriptions tab
+  const gridRenderer = findFirstObject(r, 'gridRenderer');
+  if (gridRenderer?.items) {
+    removeShorts(gridRenderer);
+  }
+
+  // Pagination
+  const gridContinuation = findFirstObject(r, 'gridContinuation');
+  if (gridContinuation?.items) {
+    removeShorts(gridContinuation);
+  }
+
+  return r;
+};
+
+function removeShorts(container) {
+  container.items = container.items.filter(
+    (elm) => elm?.tileRenderer?.onSelectCommand?.reelWatchEndpoint == null
+  );
+}
+
+function findFirstObject(haystack, needle) {
+  for (const key in haystack) {
+    if (key === needle) {
+      return haystack[key];
+    }
+    if (typeof haystack[key] === 'object') {
+      const result = findFirstObject(haystack[key], needle);
+      if (result) return result;
+    }
+  }
+  return null;
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -121,6 +121,7 @@ function createOptionsPanel() {
 
   elmContainer.appendChild(createConfigCheckbox('enableAdBlock'));
   elmContainer.appendChild(createConfigCheckbox('hideLogo'));
+  elmContainer.appendChild(createConfigCheckbox('removeShorts'));
   elmContainer.appendChild(createConfigCheckbox('enableSponsorBlock'));
 
   const elmBlock = document.createElement('blockquote');

--- a/src/userScript.js
+++ b/src/userScript.js
@@ -13,6 +13,7 @@ document.addEventListener(
 );
 
 import './adblock.js';
+import './shorts.js';
 import './sponsorblock.js';
 import './ui.js';
 


### PR DESCRIPTION
This PR adds filtering of JSON nodes containing `reelWatchEndpoint` which is an indicator that given video is a reel/short.
Due to the convoluted format of JSON responses, it might not cover all of the cases.

Reel playback seems broken on TVs and I don't really care about having them, as it's ofter reused content.
Please note that it'll only work on the Subscriptions tab (which is the one I use the most). 
However, It should be pretty easy to extend it to other tabs and search results.

Before:
<img width="1223" alt="Screenshot 2024-09-18 at 13 45 03" src="https://github.com/user-attachments/assets/fc2fe153-ad0a-4a91-8129-570c68a0133f">

After:
<img width="1228" alt="Screenshot 2024-09-18 at 13 45 21" src="https://github.com/user-attachments/assets/317a0a8b-ca36-4396-bd5a-d45ac200c749">

Green settings menu:
<img width="1216" alt="Screenshot 2024-09-18 at 13 45 37" src="https://github.com/user-attachments/assets/94e9789a-2b7a-4347-af5c-4d15cc71e691">

