### PR TITLE
Add old WebKit versions to .browserslistrc

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,6 @@
 # WAM uses WebKit on webOS 1 and 2
+safari 7 # [WebKit 537.71] for webOS 1 [WebKit 537.41]
+safari 8 # [WebKit 538.35] for webOS 2 [WebKit 538.2]
 chrome 38 # webOS 3.x
 chrome 53 # webOS 4.x
 chrome 68 # webOS 5


### PR DESCRIPTION
Safari 7/8 use almost the same WebKit versions as webOS 1/2, so add them to `.browserslistrc`.

Unfortunately, I don't think this solves the problem. But it shouldn't hurt (as long as we still have the goal of a single IPK working on all webOS versions).