### PR TITLE
Fix missing math font

### DIFF
--- a/src/font-fix.css
+++ b/src/font-fix.css
@@ -1,0 +1,26 @@
+/* LG TVs don't have a system font for math unicode symbols. */
+
+/* Source: https://fonts.googleapis.com/css2?family=Noto+Sans+Math&display=swap */
+@font-face {
+  /* font-family: 'Noto Sans Math'; */
+  font-family: Arial; /* LG TVs don't have the Arial font so replacing is safe. */
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/notosansmath/v15/7Aump_cpkSecTWaHRlH2hyV5UEl981w.woff2)
+    format('woff2');
+  unicode-range: U+0302-0303, U+0305, U+0307-0308, U+0310, U+0312, U+0315,
+    U+031A, U+0326-0327, U+032C, U+032F-0330, U+0332-0333, U+0338, U+033A,
+    U+0346, U+034D, U+0391-03A1, U+03A3-03A9, U+03B1-03C9, U+03D1, U+03D5-03D6,
+    U+03F0-03F1, U+03F4-03F5, U+2016-2017, U+2034-2038, U+203C, U+2040, U+2043,
+    U+2047, U+2050, U+2057, U+205F, U+2070-2071, U+2074-208E, U+2090-209C,
+    U+20D0-20DC, U+20E1, U+20E5-20EF, U+2100-2112, U+2114-2115, U+2117-2121,
+    U+2123-214F, U+2190, U+2192, U+2194-21AE, U+21B0-21E5, U+21F1-21F2,
+    U+21F4-2211, U+2213-2214, U+2216-22FF, U+2308-230B, U+2310, U+2319,
+    U+231C-2321, U+2336-237A, U+237C, U+2395, U+239B-23B7, U+23D0, U+23DC-23E1,
+    U+2474-2475, U+25AF, U+25B3, U+25B7, U+25BD, U+25C1, U+25CA, U+25CC, U+25FB,
+    U+266D-266F, U+27C0-27FF, U+2900-2AFF, U+2B0E-2B11, U+2B30-2B4C, U+2BFE,
+    U+3030, U+FF5B, U+FF5D, U+1D400-1D7FF, U+1EE00-1EEFF, U+0000-00FF, U+0131,
+    U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}


### PR DESCRIPTION
Load `Noto Sans Math` as `Arial` to solve the missing font issue. Youtube in browser on Windows specifies `sans-serif` on video titles which loads `Cambria Math` from the system fonts. Due to licensing issues, `Cambria Math` can't be bundled with YTAF, therefore `Noto Sans Math` is used instead.

This is safe as LG TVs don't have `Arial` installed.

Fixes #188