### PR TITLE
Fix missing voice search

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,8 @@ export function extractLaunchParams() {
 function getYTURL() {
   const ytURL = new URL('https://www.youtube.com/tv#/');
   ytURL.searchParams.append('env_forceFullAnimation', '1');
+  ytURL.searchParams.append('env_enableWebSpeech', '1');
+  ytURL.searchParams.append('env_enableVoice', '1');
   return ytURL;
 }
 


### PR DESCRIPTION
Specify `env_enableWebSpeech` and `env_enableVoice` in the URL search parameters to force Youtube to feature detect voice capabilities since normally, the server decides based on the user agent.