### PR TITLE
Fix checkbox click in the YTAF config UI

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -98,10 +98,14 @@ function createOptionsPanel() {
       } else if (evt.keyCode === 13) {
         // "OK" button
 
-        // The YouTube app generates these "OK" events from clicks (including
-        // with the Magic Remote), and we don't want to send a duplicate click
-        // event for those. It seems isTrusted is only true for "real" events.
-        if (evt.isTrusted === true) {
+        /**
+         * The YouTube app generates these "OK" events from clicks (including
+         * with the Magic Remote), and we don't want to send a duplicate click
+         * event for those. Youtube uses the `Event` class instead of
+         * `KeyboardEvent` so we check for that.
+         * See issue #143 and #200 for context.
+         */
+        if (evt instanceof KeyboardEvent) {
           document.activeElement.click();
         }
       } else if (evt.keyCode === 27) {


### PR DESCRIPTION
Replaces `isTrusted == true` check with `instanceof KeyboardEvent`, which is used to filter out Youtube-generated `Event`s. The [`isTrusted` property](https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted) is not available in Chrome versions <46 (webOS <4).

Fixes #200.