### PR TITLE
Integrate recap/preview skipping (SponsorBlock)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -36,6 +36,13 @@ const configOptions = new Map([
     }
   ],
   [
+    'enableSponsorBlockPreview',
+    {
+      default: false,
+      desc: 'Skip recaps and previews'
+    }
+  ],
+  [
     'hideLogo',
     {
       default: false,

--- a/src/sponsorblock.js
+++ b/src/sponsorblock.js
@@ -165,8 +165,9 @@ class SponsorBlockHandler {
         color: 'blue',
         opacity: 0.7
       };
-      const transform = `translateX(${(start / videoDuration) * 100.0
-        }%) scaleX(${(end - start) / videoDuration})`;
+      const transform = `translateX(${
+        (start / videoDuration) * 100.0
+      }%) scaleX(${(end - start) / videoDuration})`;
       const elm = document.createElement('div');
       elm.classList.add('ytlr-progress-bar__played');
       elm.style['background-color'] = barType.color;

--- a/src/sponsorblock.js
+++ b/src/sponsorblock.js
@@ -33,6 +33,11 @@ const barTypes = {
     color: '#ff9900',
     opacity: '0.7',
     name: 'non-music part'
+  },
+  preview: {
+    color: '#008fd6',
+    opacity: '0.7',
+    name: 'recap or preview'
   }
 };
 
@@ -67,7 +72,8 @@ class SponsorBlockHandler {
       'outro',
       'interaction',
       'selfpromo',
-      'music_offtopic'
+      'music_offtopic',
+      'preview'
     ];
     const resp = await fetch(
       `${sponsorblockAPI}/skipSegments/${videoHash}?categories=${encodeURIComponent(
@@ -114,6 +120,9 @@ class SponsorBlockHandler {
     if (configRead('enableSponsorBlockMusicOfftopic')) {
       skippableCategories.push('music_offtopic');
     }
+    if (configRead('enableSponsorBlockPreview')) {
+      skippableCategories.push('preview');
+    }
     return skippableCategories;
   }
 
@@ -156,9 +165,8 @@ class SponsorBlockHandler {
         color: 'blue',
         opacity: 0.7
       };
-      const transform = `translateX(${
-        (start / videoDuration) * 100.0
-      }%) scaleX(${(end - start) / videoDuration})`;
+      const transform = `translateX(${(start / videoDuration) * 100.0
+        }%) scaleX(${(end - start) / videoDuration})`;
       const elm = document.createElement('div');
       elm.classList.add('ytlr-progress-bar__played');
       elm.style['background-color'] = barType.color;

--- a/src/ui.js
+++ b/src/ui.js
@@ -137,6 +137,7 @@ function createOptionsPanel() {
   elmBlock.appendChild(createConfigCheckbox('enableSponsorBlockInteraction'));
   elmBlock.appendChild(createConfigCheckbox('enableSponsorBlockSelfPromo'));
   elmBlock.appendChild(createConfigCheckbox('enableSponsorBlockMusicOfftopic'));
+  elmBlock.appendChild(createConfigCheckbox('enableSponsorBlockPreview'));
 
   elmContainer.appendChild(elmBlock);
 


### PR DESCRIPTION
Integrates the "Preview" category from SponsorBlock. Unset by default as I'm not sure how much people would want it, but this and the naming/descriptions can be changed of course if it aligns better with the project's goals.

Built and installed it on my own set and it works fine for me:

![image](https://github.com/user-attachments/assets/ef6e24f0-a60f-45d6-9657-4307e611985b)
![image](https://github.com/user-attachments/assets/46aeca6a-a0ff-4635-b6f8-28797622ee2b)
