### PR TITLE
Fix CSS patches for new YT class naming

### DIFF
--- a/src/yt-fixes.css
+++ b/src/yt-fixes.css
@@ -14,7 +14,7 @@
 }
 
 /* Fixes shorts thumbnails */
-.ytlr-tile-header-renderer--shorts {
+.ytLrTileHeaderRendererShorts {
   z-index: -1;
 }
 

--- a/src/yt-fixes.css
+++ b/src/yt-fixes.css
@@ -1,5 +1,5 @@
 /* Fixes transparency effect for the video player */
-.ytLrWatchDefaultShadow{
+.ytLrWatchDefaultShadow {
   background-image: linear-gradient(
     to bottom,
     rgba(0, 0, 0, 0) 0,


### PR DESCRIPTION
YT uses camel case now instead of snake case for their CSS class names. This PR builds on top of #278 to fix the shorts thumbnail patch as well.