### PR TITLE
Remove shorts shelf from Subscriptions tab

### DIFF
--- a/src/shorts.js
+++ b/src/shorts.js
@@ -2,6 +2,8 @@
 /* global fetch:writable */
 import { configRead } from './config';
 
+const SHELF_SHORTS = 'TVHTML5_SHELF_RENDERER_TYPE_SHORTS';
+
 const origParse = JSON.parse;
 JSON.parse = function () {
   const r = origParse.apply(this, arguments);
@@ -21,12 +23,24 @@ JSON.parse = function () {
     removeShorts(gridContinuation);
   }
 
+  // Shelf on subscriptions tab
+  const sectionListRenderer = findFirstObject(r, 'sectionListRenderer');
+  if (sectionListRenderer?.contents) {
+    removeShelvesWithShorts(sectionListRenderer);
+  }
+
   return r;
 };
 
 function removeShorts(container) {
   container.items = container.items.filter(
     (elm) => elm?.tileRenderer?.onSelectCommand?.reelWatchEndpoint == null
+  );
+}
+
+function removeShelvesWithShorts(container) {
+  container.contents = container.contents.filter(
+    (elm) => elm?.shelfRenderer?.tvhtml5ShelfRendererType != SHELF_SHORTS
   );
 }
 


### PR DESCRIPTION
Filters out the new row with vertical shorts at the top of main/channel subscription page

Should resolve #271
Before:
<img width="815" alt="Screenshot 2025-05-08 at 11 58 43" src="https://github.com/user-attachments/assets/4311e1ff-09d4-4ffb-bbd1-82fcaf385a04" />

After:
<img width="813" alt="Screenshot 2025-05-08 at 11 58 59" src="https://github.com/user-attachments/assets/87e02cfd-8008-4f7a-b6ac-3825b6abbd22" />
