### PR TITLE
Fix sponsorblock segment overlay

### DIFF
--- a/src/ui.css
+++ b/src/ui.css
@@ -60,3 +60,41 @@
   padding: 0 1em;
   line-height: 0;
 }
+
+.ytaf-sponsorblock-segment-container {
+  top: 0%;
+  height: 100%;
+  width: 100%;
+  pointer-events: none;
+  position: absolute;
+  overflow: hidden;
+}
+
+// Fix: progress bar w/ chapter markers uses a different layout
+[idomkey='player-bar-renderer']
+  :not([idomkey='slider'])
+  .ytaf-sponsorblock-segment-container {
+  top: 25%;
+  height: 50%;
+}
+
+// Expand to overflow progress bar when focused
+[idomkey='progress-bar'].zylon-focus .ytaf-sponsorblock-segment-container {
+  top: -25%;
+  height: 150%;
+}
+
+.ytaf-sponsorblock-segment {
+  opacity: 0.7;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  border-radius: 9001px;
+  display: inline-block;
+}
+
+// Allow overlay segments to overflow
+[idomkey='slider'],
+[idomkey='progress-bar'] {
+  overflow: unset !important;
+}


### PR DESCRIPTION
Fix the sponsorblock segment overlay.

I've found 3 types of progress bars.

No markers:

- 2 elements with attribute `idomkey='progress-bar'`
- Progress bar contains a descendant with `idomkey='slider'`

Manual chapter markers:

- 3 elements with attribute `idomkey='progress-bar'`
- Progress bar contains descendant with attribute `idomkey='player-bar-renderer'`

Auto markers:

- 2 elements with attribute `idomkey='progress-bar'`
- Progress bar contains descendant with attribute `idomkey='player-bar-renderer'`
- `[idomkey='player-bar-renderer']` element contains a descendant with attribute `idomkey='slider'`.