### PR TITLE
Added Audio-Only Mode (Reduces OLED Burn-In) + Colour Coded Toast Messages

### DIFF
--- a/src/sponsorblock.js
+++ b/src/sponsorblock.js
@@ -294,7 +294,7 @@ class SponsorBlockHandler {
 
         const skipName = barTypes[segment.category]?.name || segment.category;
         console.info(this.videoID, 'Skipping', segment);
-        showNotification(`Skipping ${skipName}`);
+        showNotification(`Skipping ${skipName}`, 'grey', 2000);
         this.video.currentTime = end;
         this.scheduleSkip();
       },

--- a/src/sponsorblock.js
+++ b/src/sponsorblock.js
@@ -294,7 +294,7 @@ class SponsorBlockHandler {
 
         const skipName = barTypes[segment.category]?.name || segment.category;
         console.info(this.videoID, 'Skipping', segment);
-        showNotification(`Skipping ${skipName}`, 'grey', 2000);
+        showNotification(`Skipping ${skipName}`, 'indigo', 2000);
         this.video.currentTime = end;
         this.scheduleSkip();
       },

--- a/src/ui.js
+++ b/src/ui.js
@@ -223,7 +223,7 @@ const COLOR_MAP = {
   green: 'rgba(0, 162, 0, 0.9)',
   yellow: 'rgba(255, 255, 0, 0.9)',
   blue: 'rgba(0, 128, 255, 0.9)',
-  grey: 'rgba(51, 51, 51, 0.5)',
+  grey: 'rgba(255, 255, 255, 0.5)',
   none: 'rgba(0, 0, 0, 0)'
 };
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -27,8 +27,8 @@ const colorCodeMap = new Map([
   [170, 'yellow'],
 
   [406, 'blue'],
-  [191, 'blue'],
-  [167, 'blue']
+  [167, 'blue'],
+  [191, 'blue']
 ]);
 
 /**

--- a/src/ui.js
+++ b/src/ui.js
@@ -7,7 +7,7 @@ import {
   configGetDesc
 } from './config.js';
 import './ui.css';
-import { requireElement } from './player-api.ts';
+import { requireElement } from './player_api/helpers';
 
 // We handle key events ourselves.
 window.__spatialNavigation__.keyMode = 'NONE';
@@ -27,6 +27,7 @@ const colorCodeMap = new Map([
   [170, 'yellow'],
 
   [406, 'blue'],
+  [191, 'blue'],
   [167, 'blue']
 ]);
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -190,7 +190,7 @@ const eventHandler = (evt) => {
   );
 
   if (getKeyColor(evt.charCode) === 'green') {
-    console.info('Taking over : Options panel');
+    console.info('Taking over!');
 
     evt.preventDefault();
     evt.stopPropagation();
@@ -203,8 +203,6 @@ const eventHandler = (evt) => {
   }
 
   if (getKeyColor(evt.charCode) === 'blue') {
-    console.info('Taking over : Audio Only mode');
-
     evt.preventDefault();
     evt.stopPropagation();
 
@@ -297,16 +295,11 @@ function applyUIFixes() {
 }
 
 async function initAudioOnlyToggle() {
-  try {
-    const elVideo = await requireElement('video', HTMLVideoElement);
-    const elVideoVisi = elVideo.style.visibility === 'hidden';
-    elVideo.style.visibility = elVideoVisi ? '' : 'hidden';
-    const s = elVideoVisi ? 'Disabled' : 'Enabled';
-    console.log('Audio-only mode:', s);
-    showNotification('Audio-only mode: ' + s, 2000);
-  } catch {
-    console.warn('Failed to toggle audio-only mode');
-  }
+  const elVideo = await requireElement('video', HTMLVideoElement);
+  const elVideoVisi = elVideo.style.visibility === 'hidden';
+  elVideo.style.visibility = elVideoVisi ? '' : 'hidden';
+  const s = elVideoVisi ? 'Disabled' : 'Enabled';
+  showNotification('Audio-only mode: ' + s, 2000);
 }
 
 applyUIFixes();

--- a/src/ui.js
+++ b/src/ui.js
@@ -7,6 +7,7 @@ import {
   configGetDesc
 } from './config.js';
 import './ui.css';
+import { requireElement } from './player-api.ts';
 
 // We handle key events ourselves.
 window.__spatialNavigation__.keyMode = 'NONE';
@@ -26,7 +27,7 @@ const colorCodeMap = new Map([
   [170, 'yellow'],
 
   [406, 'blue'],
-  [191, 'blue']
+  [167, 'blue']
 ]);
 
 /**
@@ -188,7 +189,7 @@ const eventHandler = (evt) => {
   );
 
   if (getKeyColor(evt.charCode) === 'green') {
-    console.info('Taking over!');
+    console.info('Taking over : Options panel');
 
     evt.preventDefault();
     evt.stopPropagation();
@@ -198,6 +199,18 @@ const eventHandler = (evt) => {
       showOptionsPanel(!optionsPanelVisible);
     }
     return false;
+  }
+
+  if (getKeyColor(evt.charCode) === 'blue') {
+    console.info('Taking over : Audio Only mode');
+
+    evt.preventDefault();
+    evt.stopPropagation();
+
+    if (evt.type === 'keydown') {
+      // Toggle Audio-Only mode.
+      initAudioOnlyToggle();
+    }
   }
   return true;
 };
@@ -279,6 +292,19 @@ function applyUIFixes() {
     });
   } catch (e) {
     console.error('error setting up <body> class observer:', e);
+  }
+}
+
+async function initAudioOnlyToggle() {
+  try {
+    const elVideo = await requireElement('video', HTMLVideoElement);
+    const elVideoVisi = elVideo.style.visibility === 'hidden';
+    elVideo.style.visibility = elVideoVisi ? '' : 'hidden';
+    const s = elVideoVisi ? 'Disabled' : 'Enabled';
+    console.log('Audio-only mode:', s);
+    showNotification('Audio-only mode: ' + s, 2000);
+  } catch {
+    console.warn('Failed to toggle audio-only mode');
   }
 }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -218,7 +218,16 @@ document.addEventListener('keydown', eventHandler, true);
 document.addEventListener('keypress', eventHandler, true);
 document.addEventListener('keyup', eventHandler, true);
 
-export function showNotification(text, time = 3000) {
+const COLOR_MAP = {
+  red: 'rgba(255, 0, 0, 0.9)',
+  green: 'rgba(0, 162, 0, 0.9)',
+  yellow: 'rgba(255, 255, 0, 0.9)',
+  blue: 'rgba(0, 128, 255, 0.9)',
+  grey: 'rgba(51, 51, 51, 0.5)',
+  none: 'rgba(0, 0, 0, 0)'
+};
+
+export function showNotification(text, color = 'grey', time = 3000) {
   if (!document.querySelector('.ytaf-notification-container')) {
     console.info('Adding notification container');
     const c = document.createElement('div');
@@ -233,6 +242,7 @@ export function showNotification(text, time = 3000) {
   elmInner.classList.add('message-hidden');
   elm.appendChild(elmInner);
   document.querySelector('.ytaf-notification-container').appendChild(elm);
+  elmInner.style.borderColor = COLOR_MAP[color] || color;
 
   setTimeout(() => {
     elmInner.classList.remove('message-hidden');
@@ -299,12 +309,16 @@ async function initAudioOnlyToggle() {
   const elVideoVisi = elVideo.style.visibility === 'hidden';
   elVideo.style.visibility = elVideoVisi ? '' : 'hidden';
   const s = elVideoVisi ? 'Disabled' : 'Enabled';
-  showNotification('Audio-only mode: ' + s, 2000);
+  showNotification('Audio-only mode: ' + s, 'blue', 2000);
 }
 
 applyUIFixes();
 initHideLogo();
 
 setTimeout(() => {
-  showNotification('Press [GREEN] to open YTAF configuration screen');
-}, 2000);
+  showNotification(
+    'Press [GREEN] to open YTAF configuration screen',
+    'green',
+    2000
+  );
+});

--- a/src/video-quality.ts
+++ b/src/video-quality.ts
@@ -31,7 +31,7 @@ function handlePlaybackStart(
   const selected = player.getPlaybackQualityLabel();
   const max = player.getAvailableQualityData()[0]?.qualityLabel;
 
-  showNotification(`${selected} selected (Max ${max})`, 'white', 3000);
+  showNotification(`${selected} selected (Max ${max})`, 'grey', 3000);
 }
 
 playerManager.addEventListener('newVideo', handleNewVideo);

--- a/src/video-quality.ts
+++ b/src/video-quality.ts
@@ -31,7 +31,7 @@ function handlePlaybackStart(
   const selected = player.getPlaybackQualityLabel();
   const max = player.getAvailableQualityData()[0]?.qualityLabel;
 
-  showNotification(`${selected} selected (Max ${max})`, 3000);
+  showNotification(`${selected} selected (Max ${max})`, 'white', 3000);
 }
 
 playerManager.addEventListener('newVideo', handleNewVideo);


### PR DESCRIPTION
You know, when you are in Youtube Music and can't turn the display off or when you are listening to the long-hour podcasts with static images and shi.. or the ones with no good video and only with audio element.

The built-in screen-off feature is greyed out for YouTube, and even when it works, it doesn’t display the YouTube UI. This makes it frustrating to toggle the screen off every time you want to change video controls.

This feature enables audio only and removes the video element, thus gives you a pitch black screen. You can reduce OLED burn in and also listen to your audio without lighting the room up :)

Press the blue button (🟦) on your magic remote to toggle audio-only mode