### PR TITLE
Fix video quality not upgraded in transition from preview -> watch

### DIFF
--- a/src/player_api/custom-event-target.ts
+++ b/src/player_api/custom-event-target.ts
@@ -1,0 +1,116 @@
+type TypedEventPartial<T extends EventTarget, U> = {
+  readonly currentTarget: T | null;
+  readonly type: U;
+};
+
+type BaseTypedEvent<T extends EventTarget, E extends Event, U> = E &
+  TypedEventPartial<T, U>;
+
+type EventInstanceType<T, O> = T extends abstract new (
+  type: string,
+  options?: O
+) => infer R
+  ? R
+  : never;
+
+type EventOptionsType<T> = T extends new (
+  type: string,
+  options?: infer O
+) => Event
+  ? O
+  : never;
+
+export function asTypedEvent<
+  const E extends Event,
+  const A = EventInit
+>(event: { new (type: string, options?: A): E }) {
+  return event as {
+    new <
+      T extends EventTarget,
+      const U,
+      const O extends EventOptionsType<typeof event>
+    >(
+      type: U,
+      options?: O
+    ): BaseTypedEvent<T, EventInstanceType<typeof event, O>, U>;
+    prototype: BaseTypedEvent<EventTarget, E, string>;
+  };
+}
+
+export type TypedEvent<T extends EventTarget, U> = BaseTypedEvent<T, Event, U>;
+export const TypedEvent = asTypedEvent(Event);
+
+export type TypedCustomEvent<
+  D,
+  T extends EventTarget,
+  U = string
+> = BaseTypedEvent<T, CustomEvent<D>, U>;
+
+export const TypedCustomEvent = CustomEvent as {
+  new <const U extends string, const D = undefined>(
+    type: U,
+    eventInitDict?: CustomEventInit<D>
+  ): TypedCustomEvent<D, EventTarget, U>;
+
+  prototype: BaseTypedEvent<EventTarget, CustomEvent<unknown>, string>;
+};
+
+interface EmptyEventMap {}
+
+type EventMapValue<
+  T extends EmptyEventMap,
+  K extends keyof T & string
+> = T[K] extends Event ? T[K] : never;
+
+interface EventListener<
+  Self extends EventTarget,
+  T extends EmptyEventMap,
+  EventName extends keyof T
+> {
+  (this: Self, evt: T[EventName] & TypedEvent<Self, EventName>): void;
+}
+
+interface EventListenerObject<
+  Self extends EventTarget,
+  T extends EmptyEventMap,
+  EventName extends keyof T
+> {
+  handleEvent: EventListener<Self, T, EventName>;
+}
+
+type EventListenerArg<
+  Self extends EventTarget,
+  T extends EmptyEventMap,
+  EventName extends keyof T
+> =
+  | EventListener<Self, T, EventName>
+  | EventListenerObject<Self, T, EventName>
+  | null;
+
+interface CustomEventTarget<T extends EmptyEventMap> {
+  addEventListener<K extends keyof T & string>(
+    type: K,
+    callback: EventListenerArg<this, T, K>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<K extends keyof T & string>(
+    type: K,
+    callback: EventListenerArg<this, T, K>,
+    options?: boolean | EventListenerOptions
+  ): void;
+
+  dispatchEvent<K extends keyof T & string>(
+    event: EventMapValue<T, K>
+  ): boolean;
+}
+
+export const CustomEventTarget = EventTarget as {
+  new <T extends EmptyEventMap>(): CustomEventTarget<T>;
+  prototype: CustomEventTarget<EmptyEventMap>;
+};
+
+export type EventMapOf<T> =
+  T extends CustomEventTarget<infer U>
+    ? { [K in keyof U]: U[K] & TypedEvent<T, K> }
+    : never;

--- a/src/player_api/helpers.ts
+++ b/src/player_api/helpers.ts
@@ -1,40 +1,6 @@
-import { waitForChildAdd } from './utils';
+import { waitForChildAdd } from '../utils';
 
-export enum PlayerState {
-  UNSTARTED = -1,
-  ENDED = 0,
-  PLAYING = 1,
-  PAUSED = 2,
-  BUFFERING = 3,
-  CUED = 5
-}
-
-interface YTPlayerEventMap extends HTMLElementEventMap {
-  onStateChange: PlayerState;
-}
-
-interface VideoQualityData {
-  formatId: string | undefined;
-  qualityLabel: string;
-  quality: string;
-  isPlayable: boolean;
-  paygatedQualityDetails?: unknown;
-}
-
-export interface YTPlayer extends HTMLElement {
-  addEventListener<K extends keyof YTPlayerEventMap>(
-    type: K,
-    listener: (this: YTPlayer, ev: YTPlayerEventMap[K]) => any,
-    options?: boolean | AddEventListenerOptions
-  ): void;
-  // Player API does not support `removeEventListener`
-
-  getPlaybackQualityLabel(): string;
-
-  getAvailableQualityData(): VideoQualityData[];
-
-  setPlaybackQualityRange(min: string, max: string, formatId?: string): void;
-}
+import type { YTPlayer } from './yt-api';
 
 /**
  * document.querySelector but waits for the Element to be added if it doesn't already exist.

--- a/src/player_api/index.ts
+++ b/src/player_api/index.ts
@@ -1,0 +1,3 @@
+export * from './yt-api';
+export * from './manager';
+export type { EventMapOf } from './custom-event-target';

--- a/src/player_api/manager.ts
+++ b/src/player_api/manager.ts
@@ -1,0 +1,116 @@
+import {
+  CustomEventTarget,
+  TypedCustomEvent,
+  type EventMapOf
+} from './custom-event-target';
+import { getPlayer } from './helpers';
+import type { PlayerStateObject, VideoID, YTPlayer } from './yt-api';
+
+function diffPlayerState(
+  prev: PlayerStateObject | null,
+  next: PlayerStateObject
+) {
+  if (!prev) return next;
+
+  const changes: Partial<PlayerStateObject> = {};
+
+  for (const k in next) {
+    const key = k as keyof PlayerStateObject;
+    if (next[key] !== prev[key]) {
+      changes[key] = next[key];
+    }
+  }
+
+  return changes;
+}
+
+interface EventMap {
+  newVideo: CustomEvent<VideoID>;
+  playbackStart: CustomEvent<undefined>;
+}
+
+export enum PlayerMode {
+  PREVIEW,
+  SHORTS,
+  NORMAL
+}
+
+class PlayerManager
+  extends CustomEventTarget<EventMap>
+  implements PlayerManager
+{
+  #player;
+  #lastVideoID: VideoID | null = null;
+  #lastPlayerState: PlayerStateObject | null = null;
+  #playbackStartFired = false;
+
+  #handleNewVideo(videoID: VideoID) {
+    this.#playbackStartFired = false;
+    this.dispatchEvent(new TypedCustomEvent('newVideo', { detail: videoID }));
+  }
+
+  #handlePlayerStateChange = () => {
+    const current = this.#player.getPlayerStateObject();
+    const diff = diffPlayerState(
+      this.#lastPlayerState,
+      this.#player.getPlayerStateObject()
+    );
+    this.#lastPlayerState = current;
+
+    const currentVideoID = this.currentVideoID;
+    if (this.#lastVideoID !== currentVideoID) {
+      if (!currentVideoID) throw new Error('unexpected `null` video ID');
+      this.#handleNewVideo(currentVideoID);
+      this.#lastVideoID = currentVideoID;
+    }
+
+    if (diff.isPlaying && !this.#playbackStartFired) {
+      this.#playbackStartFired = true;
+      this.dispatchEvent(new TypedCustomEvent('playbackStart'));
+    }
+  };
+
+  constructor(player: YTPlayer) {
+    super();
+    this.#player = player;
+
+    player.addEventListener('onStateChange', this.#handlePlayerStateChange);
+  }
+
+  get currentVideoID(): VideoID | null {
+    return this.#player.getVideoData().video_id || null;
+  }
+
+  get playerMode() {
+    if (this.#player.isInline()) return PlayerMode.PREVIEW;
+
+    if (this.#player.getVideoStats().el === 'shortspage') {
+      return PlayerMode.SHORTS;
+    }
+
+    return PlayerMode.NORMAL;
+  }
+
+  get player(): YTPlayer {
+    return this.#player;
+  }
+}
+
+let instance: PlayerManager | null = null;
+
+export async function getPlayerManager(): Promise<PlayerManager> {
+  if (!instance) {
+    const player = await getPlayer();
+    instance = new PlayerManager(player);
+  }
+
+  instance.addEventListener('playbackStart', function (event) {
+    event.type;
+    event.currentTarget?.currentVideoID;
+    event.detail;
+  });
+
+  return instance;
+}
+
+export type { PlayerManager };

--- a/src/player_api/yt-api.ts
+++ b/src/player_api/yt-api.ts
@@ -1,0 +1,81 @@
+export enum PlayerState {
+  UNSTARTED = -1,
+  ENDED = 0,
+  PLAYING = 1,
+  PAUSED = 2,
+  BUFFERING = 3,
+  CUED = 5
+}
+
+interface YTPlayerEventMap extends HTMLElementEventMap {
+  onStateChange: PlayerState;
+}
+
+interface VideoQualityData {
+  formatId: string | undefined;
+  qualityLabel: string;
+  quality: string;
+  isPlayable: boolean;
+  paygatedQualityDetails?: unknown;
+}
+
+export type VideoID = string;
+
+export interface VideoData {
+  video_id: VideoID | undefined;
+}
+
+export type PlayerStateKeys =
+  | 'isBuffering'
+  | 'isCued'
+  | 'isDomPaused'
+  | 'isEnded'
+  | 'isError'
+  | 'isOrWillBePlaying'
+  | 'isPaused'
+  | 'isPlaying'
+  | 'isSeeking'
+  | 'isUiSeeking'
+  | 'isUnstarted';
+
+export type PlayerStateObject = Record<PlayerStateKeys, boolean>;
+
+export interface VideoStats {
+  el?: 'leanback' | 'shortspage';
+}
+
+export interface YTPlayer extends HTMLElement {
+  addEventListener<K extends keyof YTPlayerEventMap>(
+    type: K,
+    listener: (this: YTPlayer, ev: YTPlayerEventMap[K]) => any,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<K extends keyof YTPlayerEventMap>(
+    type: K,
+    listener: (this: YTPlayer, ev: YTPlayerEventMap[K]) => any,
+    options?: boolean | EventListenerOptions
+  ): void;
+
+  getPlaybackQualityLabel(): string; // empty if not available
+
+  /**
+   * Not available until first `isPlaying` state of playback.
+   *
+   * Empty if not available.
+   */
+  getAvailableQualityData(): VideoQualityData[];
+
+  setPlaybackQualityRange(min: string, max: string, formatId?: string): void;
+
+  getVideoData(): VideoData;
+
+  getPlayerStateObject(): PlayerStateObject;
+
+  /**
+   * `true` if playing a preview. Otherwise `false`.
+   */
+  isInline(): boolean;
+
+  getVideoStats(): VideoStats;
+}

--- a/src/screensaver-fix.ts
+++ b/src/screensaver-fix.ts
@@ -3,7 +3,7 @@
  * the entire screen, the screensaver can be kick in.
  */
 
-import { requireElement } from './player-api';
+import { requireElement } from './player_api/helpers';
 
 function isPlayerHidden(video: HTMLVideoElement) {
   // Youtube uses display none sometimes along with a negative top to hide the HTMLVideoElement.

--- a/src/watch.js
+++ b/src/watch.js
@@ -1,6 +1,6 @@
 import { configRead, configAddChangeListener } from './config';
 import './watch.css';
-import { requireElement } from './player-api.ts';
+import { requireElement } from './player_api/helpers';
 
 class Watch {
   #watch;


### PR DESCRIPTION
Fix the video quality not being upgraded when transitioning from preview playback to full-screen playback. Also refactors player API to reduce the amount of player state interpretation logic in other code.