### PR TITLE
Fix `fetch` hook exception when URL does not contain scheme

### DIFF
--- a/src/hooks/fetch.ts
+++ b/src/hooks/fetch.ts
@@ -65,7 +65,8 @@ export class FetchRegistry extends CustomEventTarget<EventMap> {
     }
 
     const url = new URL(
-      resource instanceof Request ? resource.url : resource.toString()
+      resource instanceof Request ? resource.url : resource.toString(),
+      document.location.href
     );
     const reqAllowed = this.dispatchEvent(
       new TypedCustomEvent('request', {


### PR DESCRIPTION
Bug is introduced by #346 

Fixes #347