### PR TITLE
Add Wake On LAN functionality

### DIFF
--- a/assets/appinfo.json
+++ b/assets/appinfo.json
@@ -27,5 +27,6 @@
   "supportQuickStart": true,
   "dialAppName": "YouTube",
   "disableBackHistoryAPI": true,
-  "supportGIP": true
+  "supportGIP": true,
+  "wolwowlan": true
 }


### PR DESCRIPTION
Adds the ability to turn the TV on from the Cast Menu on the YouTube Mobile app.

With the "wolwowlan" option enabled, whenever the TV is off with the suspend mode turned on in the WebOS Settings, the phone can turn the tv on whenever you attempt to cast to it from the YouTube app.

Without this option enabled, the app gives up the second the WakeOnLan packet is sent and the TV just disappears from the cast menu.