### PR TITLE
fix: blank thumbnails in shorts

### DIFF
--- a/src/yt-fixes.css
+++ b/src/yt-fixes.css
@@ -26,6 +26,10 @@
   z-index: -1;
 }
 
+ytlr-tile-renderer[style*='width: 12.75rem; height: 21.25rem;'] ytlr-tile-header-renderer {
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0) 50%) !important;
+}
+
 /**
  * Dirty hack to fix offset <video> on shorts on older webOS versions.
  * This shouldn't work but it does 😵‍💫.


### PR DESCRIPTION
Fixes #367.
All credit goes to @NZX-DeSiGN.

Technically a duplicate of #408, but since @hellyhans hasn't responded to upstream request and revised the code to avoid regressions, I thought I'd just throw this in. The authorship shouldn't matter since both of these PRs are just lifting code from an issue comment (while of course verifying its functionality).