### PR TITLE
fix: webOS 3 SyntaxError

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "postcss-preset-env": "^11.2.1",
     "prettier": "^3.8.2",
     "style-loader": "^4.0.0",
+    "terser-webpack-plugin": "^5.4.0",
     "transform-async-modules-webpack-plugin": "^1.1.1",
     "typescript": "^6.0.2",
     "webpack": "^5.106.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       style-loader:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.106.1)
+      terser-webpack-plugin:
+        specifier: ^5.4.0
+        version: 5.4.0(webpack@5.106.1)
       transform-async-modules-webpack-plugin:
         specifier: ^1.1.1
         version: 1.1.1(@babel/core@7.29.0)(@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0))(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@babel/runtime@7.28.2)(webpack@5.106.1)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 import CopyPlugin from 'copy-webpack-plugin';
 import { TransformAsyncModulesPlugin } from 'transform-async-modules-webpack-plugin';
+import TerserPlugin from 'terser-webpack-plugin';
 import pkgJson from './package.json' with { type: 'json' };
 
 /** @type {(env: Record<string, string>, argv: { mode?: string }) => (import('webpack').Configuration)[]} */
@@ -10,6 +11,14 @@ const makeConfig = (_env, argv) => [
      * to cause segfaults (at least) on nodeJS v0.12.2 used on webOS 3.x.
      */
     devtool: argv.mode === 'development' ? 'inline-source-map' : 'source-map',
+
+    optimization: {
+      /**
+       * terser doesn't pickup browserlist config
+       * See: https://github.com/terser/terser/issues/235
+       */
+      minimizer: [new TerserPlugin({ terserOptions: { ecma: 5 } })]
+    },
 
     entry: {
       index: './src/index.js',


### PR DESCRIPTION
terser (used by webpack for minification) doesn't respect browserlist and defaults to an ECMA version incompatible with webOS 3.

Fixes #378 