### PR TITLE
refactor: format `yt-fixes.css`

### DIFF
--- a/src/yt-fixes.css
+++ b/src/yt-fixes.css
@@ -26,8 +26,13 @@
   z-index: -1;
 }
 
-ytlr-tile-renderer[style*='width: 12.75rem; height: 21.25rem;'] ytlr-tile-header-renderer {
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0) 50%) !important;
+ytlr-tile-renderer[style*='width: 12.75rem; height: 21.25rem;']
+  ytlr-tile-header-renderer {
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.5) 0%,
+    rgba(0, 0, 0, 0) 50%
+  ) !important;
 }
 
 /**


### PR DESCRIPTION
formatting issue introduced in #409 was not picked up by CI because it was created before the GH workflows were updated.