### PR TITLE
Fix adblock and shorts removal not working

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,9 +11,8 @@ const { version: corejspureVersion } = require('core-js-pure/package.json');
 
 /** @type {import('@babel/core').ConfigFunction} */
 function makeConfig(api) {
-  api.cache.invalidate(() => babelruntimeVersion + corejspureVersion);
-
-  return {
+  /** @satisfies {import('@babel/core').TransformOptions} */
+  const cfg = {
     // Fixes "TypeError: __webpack_require__(...) is not a function"
     // https://github.com/webpack/webpack/issues/9379#issuecomment-509628205
     // https://babel.dev/docs/options#sourcetype
@@ -66,6 +65,12 @@ function makeConfig(api) {
       ]
     ]
   };
+
+  api.cache.invalidate(
+    () => babelruntimeVersion + corejspureVersion + JSON.stringify(cfg)
+  );
+
+  return cfg;
 }
 
 export default makeConfig;

--- a/babel.config.js
+++ b/babel.config.js
@@ -34,7 +34,12 @@ function makeConfig(api) {
         'polyfill-corejs3',
         {
           method: 'usage-pure',
-          version: corejspureVersion
+          version: corejspureVersion,
+          /** TODO: Remove after core rewrite.
+           * The way pure polyfills work completely breaks wrapper chaining.
+           * The new core will only wrap each global once, which will completely side-step the issue.
+           */
+          exclude: ['es.json.parse', 'esnext.json.parse']
         }
       ],
       [


### PR DESCRIPTION
Adblock and shorts filtering broke from the `core-js` v3.47.0 update adding a polyfill targeting `JSON.parse`. They are excluded for now in this PR pending a core rewrite.

Fixes #440 