### PR TITLE
fix: `TrustedHTML` trigger

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -144,9 +144,10 @@ function createOptionsPanel() {
 
   elmContainer.appendChild(elmBlock);
 
-  const elmSponsorLink = document.createElement('div');
-  elmSponsorLink.innerHTML =
-    '<small class="ytaf-ui-sponsor">Sponsor segments skipping - https://sponsor.ajay.app</small>';
+  const elmSponsorLink = document.createElement('small');
+  elmSponsorLink.className = 'ytaf-ui-sponsor';
+  elmSponsorLink.textContent =
+    'Sponsor segments skipping - https://sponsor.ajay.app';
   elmContainer.appendChild(elmSponsorLink);
 
   const version = document.createElement('div');


### PR DESCRIPTION
YT now serves a TrustedHTML CSP header which restricts `Element#innerHTML` assignments. Refactor out any usage of that.

There are user reports from both #441 and #427 that this issue can be attributed to. Leaving #441 open due to the author explicitly mentioning this doesn't solve it for them.

Fixes #427 