### PR TITLE
fix(adblock): harden isInlinePlaybackNoAd against property locker

### DIFF
--- a/src/hooks/json-stringify.ts
+++ b/src/hooks/json-stringify.ts
@@ -18,10 +18,33 @@ function stringify(
     // TODO: add below to a dump-level logger
     // console.debug('JSON.stringify', value, replacer, space);
 
-    // @ts-expect-error TS doesn't allow optional chaining on `unknown`. See: https://github.com/microsoft/TypeScript/issues/37700
-    const ctx = value?.playbackContext?.contentPlaybackContext as unknown;
-    if (!isPrimitive(ctx)) {
-      (ctx as Record<string, unknown>).isInlinePlaybackNoAd = true;
+    const holder = value as Record<string, any>;
+    const pbCtx = holder.playbackContext as Record<string, any> | undefined;
+    const ctx = pbCtx?.contentPlaybackContext as
+      | Record<string, unknown>
+      | undefined;
+
+    if (!isPrimitive(ctx) && ctx!.isInlinePlaybackNoAd !== true) {
+      // Setting `isInlinePlaybackNoAd` tells InnerTube not to serve ads, which
+      // avoids the server-side SABR "backoff" that otherwise stalls playback
+      // after a few seconds. YouTube has shipped a "locker" script that defines
+      // this property as non-writable/non-configurable via Object.defineProperty,
+      // so a direct assignment (`ctx.isInlinePlaybackNoAd = true`) silently fails.
+      //
+      // Instead of mutating YouTube's object in place, rebuild the holder chain
+      // with fresh plain objects. `JSON.stringify` only serializes own enumerable
+      // properties, so spreading reproduces exactly what would be serialized while
+      // dropping any locked property descriptors, letting our flag stick.
+      value = {
+        ...holder,
+        playbackContext: {
+          ...pbCtx,
+          contentPlaybackContext: {
+            ...ctx,
+            isInlinePlaybackNoAd: true
+          }
+        }
+      };
       console.info(`[JSON.stringify] Set isInlinePlaybackNoAd`);
     }
   }


### PR DESCRIPTION
## Problem

Playback aborts after a few seconds with a YouTube error screen when ads are stripped (e.g. #457). This is YouTube's server-side SABR "backoff": when the client receives no ads, the server instructs it to wait instead of sending media data, which surfaces as fake buffering and then an error.

The existing mitigation (added in #332) sets `playbackContext.contentPlaybackContext.isInlinePlaybackNoAd = true` in player requests so InnerTube serves no ads — and therefore no backoff.

## Root cause

YouTube ships a "locker" script that defines `isInlinePlaybackNoAd` as non-writable / non-configurable via `Object.defineProperty`. The previous code set the flag with a direct in-place assignment (`ctx.isInlinePlaybackNoAd = true`), which **silently fails** against a locked descriptor (no throw in non-strict mode). The flag never makes it into the request, the backoff returns, and playback stalls.

## Fix

Instead of mutating YouTube's object in place, rebuild the holder chain (`holder → playbackContext → contentPlaybackContext`) with fresh plain objects via spread. `JSON.stringify` only serializes own enumerable properties, so the spread reproduces exactly what would be serialized while dropping any locked property descriptors — so our flag sticks.

The clone is only built when a `contentPlaybackContext` is present and the flag isn't already set, so the hot path of `JSON.stringify` is unaffected.

## Testing

- `pnpm run lint:tsc`, `pnpm run lint:prettier`, `pnpm run lint:eslint` and `pnpm run build` all pass.
- Manually verified on hardware (LG webOS 6.5.3): a video that previously aborted after ~30 s now plays through, and the console logs `[JSON.stringify] Set isInlinePlaybackNoAd`.

Fixes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)