### PR TITLE
fix: clone in `stringify` hook to work around frozen objects

### DIFF
--- a/src/hooks/json-stringify.ts
+++ b/src/hooks/json-stringify.ts
@@ -15,6 +15,7 @@ function stringify(
   space?: string | number
 ): string {
   if (!isPrimitive(value)) {
+    value = structuredClone(value);
     // TODO: add below to a dump-level logger
     // console.debug('JSON.stringify', value, replacer, space);
 


### PR DESCRIPTION
Objects are sometimes frozen by YT to prevent modification. Clone them to work around it. Resolves fake-buffering for people who are unfortunate enough to get the flag for it.