### PR TITLE
feat: add option to pin the watch

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -57,6 +57,13 @@ const configOptions = new Map([
     }
   ],
   [
+    'keepWatchPinned',
+    {
+      default: false,
+      desc: 'Keep Time Pinned'
+    }
+  ],
+  [
     'forceHighResVideo',
     {
       default: false,

--- a/src/ui.js
+++ b/src/ui.js
@@ -126,6 +126,7 @@ function createOptionsPanel() {
   elmContainer.appendChild(createConfigCheckbox('upgradeThumbnails'));
   elmContainer.appendChild(createConfigCheckbox('hideLogo'));
   elmContainer.appendChild(createConfigCheckbox('showWatch'));
+  elmContainer.appendChild(createConfigCheckbox('keepWatchPinned'));
   elmContainer.appendChild(createConfigCheckbox('removeShorts'));
   elmContainer.appendChild(createConfigCheckbox('forceHighResVideo'));
   elmContainer.appendChild(createConfigCheckbox('removeEndscreen'));

--- a/src/watch.js
+++ b/src/watch.js
@@ -6,6 +6,8 @@ class Watch {
   #watch;
   #timer;
   #attrChanges;
+  #player = null;
+  #pinned = false;
   #PLAYER_SELECTOR = 'ytlr-watch-default';
 
   constructor() {
@@ -40,23 +42,35 @@ class Watch {
   }
 
   playerAppear(video) {
-    this.changeVisibility(video);
+    this.changeVisibility();
     this.playerObserver(video);
   }
 
-  changeVisibility(video) {
-    const focused = video.getAttribute('hybridnavfocusable') === 'true';
+  changeVisibility() {
+    // When pinned the clock stays visible regardless of whether the player is
+    // focused.
+    if (this.#pinned) {
+      this.#watch.style.display = 'block';
+      return;
+    }
+
+    const focused = this.#player?.getAttribute('hybridnavfocusable') === 'true';
     this.#watch.style.display = focused ? 'none' : 'block';
   }
 
+  setPinned(pinned) {
+    this.#pinned = pinned;
+    this.changeVisibility();
+  }
+
   async playerEvents() {
-    const player = await requireElement(this.#PLAYER_SELECTOR, HTMLElement);
-    this.playerAppear(player);
+    this.#player = await requireElement(this.#PLAYER_SELECTOR, HTMLElement);
+    this.playerAppear(this.#player);
   }
 
   playerObserver(node) {
     this.#attrChanges = new MutationObserver(() => {
-      this.changeVisibility(node);
+      this.changeVisibility();
     });
 
     this.#attrChanges.observe(node, {
@@ -74,17 +88,25 @@ class Watch {
 
 let watchInstance = null;
 
-function toggleWatch(show) {
-  if (show) {
+function refreshWatch() {
+  const pinned = configRead('keepWatchPinned');
+
+  // The clock exists while either the config option is on or it's pinned.
+  if (configRead('showWatch') || pinned) {
     watchInstance = watchInstance ? watchInstance : new Watch();
+    watchInstance.setPinned(pinned);
   } else {
     watchInstance?.destroy();
     watchInstance = null;
   }
 }
 
-toggleWatch(configRead('showWatch'));
+refreshWatch();
 
-configAddChangeListener('showWatch', (evt) => {
-  toggleWatch(evt.detail.newValue);
+configAddChangeListener('showWatch', () => {
+  refreshWatch();
+});
+
+configAddChangeListener('keepWatchPinned', () => {
+  refreshWatch();
 });


### PR DESCRIPTION
'Display time in UI' shows time only in yotube menu and closes when player gets focus. This feature keeps time pinned on the screen all time long. 
It resides in the options under 'Keep Time Pinned'.