### PR TITLE
Fix #401 - Casting from phone to TV doesn’t work — nothing happens

### DIFF
--- a/src/block-webos-cast.ts
+++ b/src/block-webos-cast.ts
@@ -4,6 +4,7 @@
  * kept asleep when the app was not started by a cast launch.
  */
 
+import { configRead } from './config';
 import type { webOSLaunchParams } from './globals';
 import { FetchRegistry } from './hooks';
 
@@ -41,6 +42,7 @@ FetchRegistry.getInstance().addEventListener('request', (evt) => {
   const { url } = evt.detail;
 
   if (url.pathname !== '/wake_cast_core') return;
+  if (!configRead('blockWebosCast')) return;
   if (castLaunch) return;
 
   evt.preventDefault();

--- a/src/block-webos-cast.ts
+++ b/src/block-webos-cast.ts
@@ -1,10 +1,47 @@
 /**
- * Fixes webosbrew/youtube-webos/issues/343
+ * Fixes webosbrew/youtube-webos/issues/343 without breaking casting
+ * (webosbrew/youtube-webos/issues/401): the webOS Chromecast service is only
+ * kept asleep when the app was not started by a cast launch.
  */
 
+import type { webOSLaunchParams } from './globals';
 import { FetchRegistry } from './hooks';
 
+// `dialLaunch`/`pairingCode` mark a DIAL launch, `cc2` a Cast Connect one.
+const CAST_LAUNCH_PARAMS = ['dialLaunch', 'pairingCode', 'cc2'];
+
+function hasCastParams(query: string) {
+  const params = new URLSearchParams(query);
+  return CAST_LAUNCH_PARAMS.some((key) => params.has(key));
+}
+
+function isCastLaunch(params: webOSLaunchParams) {
+  const { target, contentTarget = target } = params;
+  if (typeof contentTarget !== 'string') return false;
+
+  const queryStart = contentTarget.indexOf('?');
+
+  return hasCastParams(
+    queryStart === -1 ? contentTarget : contentTarget.slice(queryStart + 1)
+  );
+}
+
+// `handleLaunch` folds the launch params into the YouTube URL.
+let castLaunch = hasCastParams(window.location.search);
+
+document.addEventListener(
+  'webOSRelaunch',
+  (evt) => {
+    if (isCastLaunch(evt.detail)) castLaunch = true;
+  },
+  true
+);
+
 FetchRegistry.getInstance().addEventListener('request', (evt) => {
-  const { url, resource, init } = evt.detail;
-  if (url.pathname === '/wake_cast_core') evt.preventDefault();
+  const { url } = evt.detail;
+
+  if (url.pathname !== '/wake_cast_core') return;
+  if (castLaunch) return;
+
+  evt.preventDefault();
 });

--- a/src/config.js
+++ b/src/config.js
@@ -76,6 +76,13 @@ const configOptions = new Map([
       default: false,
       desc: 'Bypass initial account selection on startup'
     }
+  ],
+  [
+    'blockWebosCast',
+    {
+      default: true,
+      desc: 'Block webOS Cast service'
+    }
   ]
 ]);
 

--- a/src/ui.css
+++ b/src/ui.css
@@ -13,6 +13,8 @@
   padding: 1em;
   font-size: 1.4rem;
   z-index: 1000;
+  box-sizing: border-box;
+  overflow-y: auto;
 }
 
 .ytaf-ui-container :focus {

--- a/src/ui.js
+++ b/src/ui.js
@@ -130,6 +130,7 @@ function createOptionsPanel() {
   elmContainer.appendChild(createConfigCheckbox('forceHighResVideo'));
   elmContainer.appendChild(createConfigCheckbox('removeEndscreen'));
   elmContainer.appendChild(createConfigCheckbox('autoAccountSelect'));
+  elmContainer.appendChild(createConfigCheckbox('blockWebosCast'));
   elmContainer.appendChild(createConfigCheckbox('enableSponsorBlock'));
 
   const elmBlock = document.createElement('blockquote');


### PR DESCRIPTION
Hey, 

#401 was bugging me on a daily basis, so I used claude code to dig into it. So full disclaimer, the entire code is vibed.
Even though: I tested it myself thoroughly and reviewed all changes personally.

`block-webos-cast.ts` blocked every `/wake_cast_core` request in order to fix
#343. That endpoint is what brings up the cast receiver, so casting to the app
stopped working in 0.5.0. The service is now only kept asleep when the app was
not started by a cast launch.

Verified on an OLED77C57LA (SDK 10.3.1, firmware 33.31.68) by logging the
decision on the device:

| Launch | `contentTarget` | Wakeup |
| --- | --- | --- |
| Home screen | absent | blocked |
| DIAL | `pairingCode=<uuid>&theme=cl&dialLaunch=watch` | allowed |
| Cast Connect | `https://www.youtube.com/tv?cc2=1` | allowed |

Casting uses two different paths, and only DIAL carries pairing params — `cc2`
is what covers the cold-start case that actually failed. This is likely also
why casting from desktop Chrome was reported as broken.

Also adds a `blockWebosCast` option as an escape hatch, which required making
the options panel scroll instead of overflow. 
If you don't like the option, I can remove it by dropping the second commit. I kept it because it was a huge benefit while testing and could be a possible workaround if casting breaks again.

I am really looking forward to your feedback :+1: 